### PR TITLE
Minor tweak to is.empty

### DIFF
--- a/R/empty.R
+++ b/R/empty.R
@@ -15,8 +15,11 @@
 #' @return a boolean whether or not the object is empty.
 #' @export
 is.empty <- function(obj) {
-  if (methods::is(obj, "list")) { return(all(vapply(obj, is.empty, logical(1)))) }
-  suppressWarnings(is.na(obj) || is.null(obj) || NROW(obj) == 0 || obj == "")
+  if (methods::is(obj, "list")) {
+    all(vapply(obj, is.empty, logical(1)))
+  } else {
+    suppressWarnings(is.na(obj) || is.null(obj) || NROW(obj) == 0 || identical(obj, ""))
+  }
 }
 
 #' @rdname is.empty

--- a/tests/testthat/test-empty.R
+++ b/tests/testthat/test-empty.R
@@ -27,4 +27,6 @@ test_that("it is FALSE for everything else", {
   expect_false(is.empty(iris))
   expect_false(is.empty(list(NA, NULL, 1)))
   expect_false(is.empty(list(a = list(NA, NA), b = list(1, 2))))
+  expect_false(is.empty(c("", "a")))
 })
+

--- a/tests/testthat/test-package-exports-checked.R
+++ b/tests/testthat/test-package-exports-checked.R
@@ -1,4 +1,4 @@
-context("pacakge_exports_checked")
+context("package_exports_checked")
 
 test_that("it passes when all exported functions are checked", {
   devtools::install("fakepackages/allexportedchecked")


### PR DESCRIPTION
@peterhurford Using `identical` over `==` to prevent things like

``` r
> obj <- c("", "foo")
> suppressWarnings(is.na(obj) || is.null(obj) || NROW(obj) == 0 || obj == "")
[1] TRUE
```
